### PR TITLE
use url if provided in options for connect

### DIFF
--- a/lib/gridfs-service.js
+++ b/lib/gridfs-service.js
@@ -25,17 +25,22 @@ GridFSService.prototype.connect = function (cb) {
   var self = this;
 
   if (!this.db) {
-    var url = (self.options.username && self.options.password) ?
-      'mongodb://{$username}:{$password}@{$host}:{$port}/{$database}' :
-      'mongodb://{$host}:{$port}/{$database}';
+    var url;
+    if (!self.options.url) {
+      url = (self.options.username && self.options.password) ?
+        'mongodb://{$username}:{$password}@{$host}:{$port}/{$database}' :
+        'mongodb://{$host}:{$port}/{$database}';
 
-    // replace variables
-    url = url.replace(/\{\$([a-zA-Z0-9]+)\}/g, function (pattern, option) {
-      return self.options[option] || pattern;
-    });
+      // replace variables
+      url = url.replace(/\{\$([a-zA-Z0-9]+)\}/g, function (pattern, option) {
+        return self.options[option] || pattern;
+      });
+    } else {
+      url = self.options.url;
+    }
 
     // connect
-    MongoClient.connect(url, function (error, db) {
+    MongoClient.connect(url, self.options, function (error, db) {
       if (!error) {
         self.db = db;
       }


### PR DESCRIPTION
if url is set in the options for connect, it uses the url directly, otherwise it creates the url from the options parameters (as before)